### PR TITLE
Add notebook for EDA and regression

### DIFF
--- a/notebooks/eda_linear_regression.ipynb
+++ b/notebooks/eda_linear_regression.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e496b805",
+   "metadata": {},
+   "source": [
+    "## Powerlifting EDA and Linear Regression\n",
+    "This notebook performs exploratory data analysis (EDA) and a linear regression model on the [OpenPowerlifting](https://www.openpowerlifting.org/) dataset. It aims to highlight the features most strongly associated with squat, bench press and deadlift results over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b25012a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "from sklearn.metrics import r2_score\n",
+    "from sklearn.model_selection import train_test_split"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d62fbafc",
+   "metadata": {},
+   "source": [
+    "### Download dataset\n",
+    "The following cell downloads the latest OpenPowerlifting archive and reads it into a DataFrame. If the archive is already present it will be reused."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37f4e6e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import zipfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "DATA_ZIP = Path(\"openpowerlifting-latest.zip\")\n",
+    "CSV_NAME = Path(\"openpowerlifting-latest.csv\")\n",
+    "\n",
+    "if not CSV_NAME.exists():\n",
+    "    if not DATA_ZIP.exists():\n",
+    "        r = requests.get(\"https://openpowerlifting.gitlab.io/opl-csv/files/openpowerlifting-latest.zip\")\n",
+    "        r.raise_for_status()\n",
+    "        DATA_ZIP.write_bytes(r.content)\n",
+    "    with zipfile.ZipFile(DATA_ZIP) as z:\n",
+    "        z.extract(CSV_NAME.name)\n",
+    "\n",
+    "df = pd.read_csv(CSV_NAME)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7648a54c",
+   "metadata": {},
+   "source": [
+    "### Basic cleaning\n",
+    "For this example only a subset of columns is used and rows with missing data are dropped."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d650d9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cols = [\"Date\", \"Name\", \"Sex\", \"BodyweightKg\", \"Best3SquatKg\", \"Best3BenchKg\", \"Best3DeadliftKg\", \"TotalKg\", \"Age\"]\n",
+    "df = df[cols].dropna()\n",
+    "df[\"Date\"] = pd.to_datetime(df[\"Date\"])\n",
+    "df[\"Year\"] = df[\"Date\"].dt.year\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e135926",
+   "metadata": {},
+   "source": [
+    "### EDA\n",
+    "We inspect summary statistics and correlations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74003a76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "386583fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "corr = df[[\"BodyweightKg\", \"Age\", \"Year\", \"Best3SquatKg\", \"Best3BenchKg\", \"Best3DeadliftKg\", \"TotalKg\"]].corr()\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "sns.heatmap(corr, annot=True, cmap=\"coolwarm\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35a832f1",
+   "metadata": {},
+   "source": [
+    "### Linear Regression\n",
+    "A simple multiple linear regression is fitted separately for squat, bench and deadlift using bodyweight, age and year as predictors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d74c3e09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display\n",
+    "\n",
+    "features = [\"BodyweightKg\", \"Age\", \"Year\"]\n",
+    "results = {}\n",
+    "for target in [\"Best3SquatKg\", \"Best3BenchKg\", \"Best3DeadliftKg\"]:\n",
+    "    X_train, X_test, y_train, y_test = train_test_split(df[features], df[target], random_state=42)\n",
+    "    model = LinearRegression().fit(X_train, y_train)\n",
+    "    preds = model.predict(X_test)\n",
+    "    r2 = r2_score(y_test, preds)\n",
+    "    results[target] = {\"model\": model, \"r2\": r2}\n",
+    "    display({\"target\": target, \"r2\": r2})\n",
+    "    coefs = pd.Series(model.coef_, index=features)\n",
+    "    display(coefs.sort_values(key=abs, ascending=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0899ae0",
+   "metadata": {},
+   "source": [
+    "### Feature importance\n",
+    "The coefficients indicate which variables contribute most strongly to each lift prediction. Larger absolute values correspond to stronger relationships."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add new notebook `eda_linear_regression.ipynb` with code for loading the OpenPowerlifting dataset
- perform basic cleaning, EDA and simple linear regression
- show how to compute feature importance for squat, bench and deadlift

## Testing
- `pre-commit run --files notebooks/eda_linear_regression.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68417817ecbc8327956074bd4bbf8d04